### PR TITLE
Add @JvmStatic annotation to `using` function

### DIFF
--- a/ta_library/src/main/java/com/github/marlonlom/utilities/timeago/TimeAgo.kt
+++ b/ta_library/src/main/java/com/github/marlonlom/utilities/timeago/TimeAgo.kt
@@ -244,6 +244,7 @@ private constructor() {
          * @return the 'time ago' formatted text using date time
          * @see TimeAgoMessages
          */
+        @JvmStatic
         @JvmOverloads
         fun using(time: Long, resources: TimeAgoMessages = TimeAgoMessages.Builder().defaultLocale().build()): String {
             val dim = getTimeDistanceInMinutes(time)


### PR DESCRIPTION
This annotation specifies that an additional static method needs to be generated so that we can still use `TimeAgo.using()` instead of `TimeAgo.Companion.using()` in Java