### PR TITLE
Removed double single quote for IT locale

### DIFF
--- a/ta_library/src/main/resources/com/github/marlonlom/utilities/timeago/messages_it.properties
+++ b/ta_library/src/main/resources/com/github/marlonlom/utilities/timeago/messages_it.properties
@@ -17,7 +17,7 @@
 ml.timeago.now=proprio adesso
 ml.timeago.oneminute.past=uno giorno fa
 ml.timeago.xminutes.past={0} minuti fa
-ml.timeago.aboutanhour.past=circa un''ora fa
+ml.timeago.aboutanhour.past=circa un'ora fa
 ml.timeago.xhours.past={0} ore fa
 ml.timeago.oneday.past=ieri
 ml.timeago.xdays.past={0} giorni fa
@@ -31,7 +31,7 @@ ml.timeago.almosttwoyears.past=quasi due anni fa
 ml.timeago.xyears.past={0} anni fa
 ml.timeago.oneminute.future=entro un minuto
 ml.timeago.xminutes.future=entro {0} minuti
-ml.timeago.aboutanhour.future=a circa un''ora
+ml.timeago.aboutanhour.future=a circa un'ora
 ml.timeago.xhours.future=entro {0} ore
 ml.timeago.oneday.future=domani
 ml.timeago.xdays.future=entro {0} giorni


### PR DESCRIPTION
Like in the issue #4 for the French translations, there were double single quotes also in the Italian ones.
This PR fixes that by removing one single quote.

Example: `circa un''ora` -> `circa un'ora`